### PR TITLE
FOGL-2538: switched to use getAssetDateUserTime

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -193,7 +193,7 @@ const string& getReadingString(const Reading& reading)
 	string &m_value = *value;
 
 	// Convert reading data into JSON string
-	m_value.append("{\"timestamp\" : \"" + reading.getAssetDateTime(Reading::FMT_STANDARD) + "Z" + "\"");
+	m_value.append("{\"timestamp\" : \"" + reading.getAssetDateUserTime(Reading::FMT_STANDARD) + "Z" + "\"");
 	m_value.append(",\"asset\" : \"" + reading.getAssetName() + "\"");
 	m_value.append(",\"key\" : \"" + reading.getUuid() + "\"");
 	m_value.append(",\"readings\" : {");


### PR DESCRIPTION
sample data in FogLAMP - retrieved from the API so in LOCAL time
```
{
  "count": 1,
  "rows": [
    {
      "id": 1,
      "reading": {
        "value": 5
      },
      "user_ts": "2019-02-27 11:01:05.123456",
      "ts": "2019-02-28 11:22:21.750"
    }
  ]
}
```

message sent  - as UTC time : 
```
message 1 |[{'readings': {'value': 5}, 'timestamp': '2019-02-27T10:01:05.123456Z', 'asset': 'case_2331_001_006_OK', 'key': 'f1cfff7a-3769-4f47-9ded-00000000005'}]|

```